### PR TITLE
Standardize release notes categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,7 +4,10 @@ changelog:
       labels:
         - Semver-Minor
         - enhancement
-    - title: Dependency updates
+    - title: Dependency updates (GitHub Actions)
+      labels:
+        - github_actions
+    - title: Dependency updates (Other)
       labels:
         - dependencies
     - title: Other Changes


### PR DESCRIPTION
## Summary
- split dependency updates between GitHub Actions and other packages
- align release drafter config with org standard

## Testing
- not applicable