### PR TITLE
fix: skip actions with undefined name or repo in duplicate detection

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -143,6 +143,19 @@ describe('findDuplicatesByNameRepo', () => {
     const result = findDuplicatesByNameRepo(actions)
     expect(result).toHaveLength(0)
   })
+
+  test('ignores actions with undefined name or repo and does not group them together', () => {
+    const actions: ActionLike[] = [
+      {name: undefined, repo: 'repo-a', path: 'path-1'},
+      {name: undefined, repo: 'repo-a', path: 'path-2'},
+      {name: 'action-b', repo: undefined, path: 'path-3'},
+      {name: 'action-b', repo: undefined, path: 'path-4'},
+      {name: undefined, repo: undefined, path: 'path-5'}
+    ]
+
+    const result = findDuplicatesByNameRepo(actions)
+    expect(result).toHaveLength(0)
+  })
 })
 
 describe('reportDuplicateActions', () => {

--- a/dist/main.js
+++ b/dist/main.js
@@ -31441,74 +31441,6 @@ var require_dist = __commonJS({
   }
 });
 
-// node_modules/dotenv/package.json
-var require_package = __commonJS({
-  "node_modules/dotenv/package.json"(exports2, module2) {
-    module2.exports = {
-      name: "dotenv",
-      version: "17.3.1",
-      description: "Loads environment variables from .env file",
-      main: "lib/main.js",
-      types: "lib/main.d.ts",
-      exports: {
-        ".": {
-          types: "./lib/main.d.ts",
-          require: "./lib/main.js",
-          default: "./lib/main.js"
-        },
-        "./config": "./config.js",
-        "./config.js": "./config.js",
-        "./lib/env-options": "./lib/env-options.js",
-        "./lib/env-options.js": "./lib/env-options.js",
-        "./lib/cli-options": "./lib/cli-options.js",
-        "./lib/cli-options.js": "./lib/cli-options.js",
-        "./package.json": "./package.json"
-      },
-      scripts: {
-        "dts-check": "tsc --project tests/types/tsconfig.json",
-        lint: "standard",
-        pretest: "npm run lint && npm run dts-check",
-        test: "tap run tests/**/*.js --allow-empty-coverage --disable-coverage --timeout=60000",
-        "test:coverage": "tap run tests/**/*.js --show-full-coverage --timeout=60000 --coverage-report=text --coverage-report=lcov",
-        prerelease: "npm test",
-        release: "standard-version"
-      },
-      repository: {
-        type: "git",
-        url: "git://github.com/motdotla/dotenv.git"
-      },
-      homepage: "https://github.com/motdotla/dotenv#readme",
-      funding: "https://dotenvx.com",
-      keywords: [
-        "dotenv",
-        "env",
-        ".env",
-        "environment",
-        "variables",
-        "config",
-        "settings"
-      ],
-      readmeFilename: "README.md",
-      license: "BSD-2-Clause",
-      devDependencies: {
-        "@types/node": "^18.11.3",
-        decache: "^4.6.2",
-        sinon: "^14.0.1",
-        standard: "^17.0.0",
-        "standard-version": "^9.5.0",
-        tap: "^19.2.0",
-        typescript: "^4.8.4"
-      },
-      engines: {
-        node: ">=12"
-      },
-      browser: {
-        fs: false
-      }
-    };
-  }
-});
-
 // node_modules/dotenv/lib/main.js
 var require_main = __commonJS({
   "node_modules/dotenv/lib/main.js"(exports2, module2) {
@@ -31516,22 +31448,15 @@ var require_main = __commonJS({
     var path2 = require("path");
     var os5 = require("os");
     var crypto2 = require("crypto");
-    var packageJson = require_package();
-    var version = packageJson.version;
     var TIPS = [
-      "\u{1F510} encrypt with Dotenvx: https://dotenvx.com",
-      "\u{1F510} prevent committing .env to code: https://dotenvx.com/precommit",
-      "\u{1F510} prevent building .env in docker: https://dotenvx.com/prebuild",
-      "\u{1F916} agentic secret storage: https://dotenvx.com/as2",
-      "\u26A1\uFE0F secrets for agents: https://dotenvx.com/as2",
-      "\u{1F6E1}\uFE0F auth for agents: https://vestauth.com",
-      "\u{1F6E0}\uFE0F  run anywhere with `dotenvx run -- yourcommand`",
-      "\u2699\uFE0F  specify custom .env file path with { path: '/custom/path/.env' }",
-      "\u2699\uFE0F  enable debug logging with { debug: true }",
-      "\u2699\uFE0F  override existing env vars with { override: true }",
-      "\u2699\uFE0F  suppress all logs with { quiet: true }",
-      "\u2699\uFE0F  write to custom object with { processEnv: myObject }",
-      "\u2699\uFE0F  load multiple .env files with { path: ['.env.local', '.env'] }"
+      "\u25C8 encrypted .env [www.dotenvx.com]",
+      "\u25C8 secrets for agents [www.dotenvx.com]",
+      "\u2301 auth for agents [www.vestauth.com]",
+      "\u2318 custom filepath { path: '/custom/path/.env' }",
+      "\u2318 enable debugging { debug: true }",
+      "\u2318 override existing { override: true }",
+      "\u2318 suppress logs { quiet: true }",
+      "\u2318 multiple files { path: ['.env.local', '.env'] }"
     ];
     function _getRandomTip() {
       return TIPS[Math.floor(Math.random() * TIPS.length)];
@@ -31596,13 +31521,13 @@ var require_main = __commonJS({
       return DotenvModule.parse(decrypted);
     }
     function _warn(message) {
-      console.error(`[dotenv@${version}][WARN] ${message}`);
+      console.error(`\u26A0 ${message}`);
     }
     function _debug(message) {
-      console.log(`[dotenv@${version}][DEBUG] ${message}`);
+      console.log(`\u2506 ${message}`);
     }
     function _log(message) {
-      console.log(`[dotenv@${version}] ${message}`);
+      console.log(`\u25C7 ${message}`);
     }
     function _dotenvKey(options) {
       if (options && options.DOTENV_KEY && options.DOTENV_KEY.length > 0) {
@@ -31673,7 +31598,7 @@ var require_main = __commonJS({
       const debug2 = parseBoolean(process.env.DOTENV_CONFIG_DEBUG || options && options.debug);
       const quiet = parseBoolean(process.env.DOTENV_CONFIG_QUIET || options && options.quiet);
       if (debug2 || !quiet) {
-        _log("Loading env from encrypted .env.vault");
+        _log("loading env from encrypted .env.vault");
       }
       const parsed = DotenvModule._parseVault(options);
       let processEnv = process.env;
@@ -31696,7 +31621,7 @@ var require_main = __commonJS({
         encoding = options.encoding;
       } else {
         if (debug2) {
-          _debug("No encoding is specified. UTF-8 is used by default");
+          _debug("no encoding is specified (UTF-8 is used by default)");
         }
       }
       let optionPaths = [dotenvPath];
@@ -31718,7 +31643,7 @@ var require_main = __commonJS({
           DotenvModule.populate(parsedAll, parsed, options);
         } catch (e2) {
           if (debug2) {
-            _debug(`Failed to load ${path3} ${e2.message}`);
+            _debug(`failed to load ${path3} ${e2.message}`);
           }
           lastError = e2;
         }
@@ -31735,12 +31660,12 @@ var require_main = __commonJS({
             shortPaths.push(relative);
           } catch (e2) {
             if (debug2) {
-              _debug(`Failed to load ${filePath} ${e2.message}`);
+              _debug(`failed to load ${filePath} ${e2.message}`);
             }
             lastError = e2;
           }
         }
-        _log(`injecting env (${keysCount}) from ${shortPaths.join(",")} ${dim(`-- tip: ${_getRandomTip()}`)}`);
+        _log(`injected env (${keysCount}) from ${shortPaths.join(",")} ${dim(`// tip: ${_getRandomTip()}`)}`);
       }
       if (lastError) {
         return { parsed: parsedAll, error: lastError };
@@ -31754,7 +31679,7 @@ var require_main = __commonJS({
       }
       const vaultPath = _vaultPath(options);
       if (!vaultPath) {
-        _warn(`You set DOTENV_KEY but you are missing a .env.vault file at ${vaultPath}. Did you forget to build it?`);
+        _warn(`you set DOTENV_KEY but you are missing a .env.vault file at ${vaultPath}`);
         return DotenvModule.configDotenv(options);
       }
       return DotenvModule._configVault(options);
@@ -45500,6 +45425,7 @@ function fixResponseChunkedTransferBadEnding(request2, errorCallback) {
 function findDuplicatesByNameRepo(actions) {
   const grouped = /* @__PURE__ */ new Map();
   for (const action of actions) {
+    if (!action.name || !action.repo) continue;
     const key = `${action.name} | ${action.repo}`;
     const group = grouped.get(key);
     if (group) {

--- a/src/duplicates.ts
+++ b/src/duplicates.ts
@@ -16,6 +16,7 @@ export function findDuplicatesByNameRepo(
 ): DuplicateGroup[] {
   const grouped = new Map<string, ActionLike[]>()
   for (const action of actions) {
+    if (!action.name || !action.repo) continue
     const key = `${action.name} | ${action.repo}`
     const group = grouped.get(key)
     if (group) {


### PR DESCRIPTION
Skip actions where name or repo is undefined to prevent incorrect grouping under a shared key. Also adds a test case for this scenario.