### PR TITLE
fix: preserve hyphens and special chars in action names

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {expect, test} from '@jest/globals'
 import {GetDateFormatted} from '../src/utils'
 import {parseYAML} from '../src/utils'
 import {sanitize} from '../src/utils'
+import {removeGreaterLessThan} from '../src/utils'
 import {isInTestFolder} from '../src/utils'
 
 test('date parsing', () => {
@@ -24,8 +25,8 @@ test(`check parseYAML with normal strings`, () => {
   const filePath = 'test'
   const result = parseYAML(filePath, 'test', content)
 
-  expect(result.name).toBe('testname')
-  expect(result.author).toBe('testauthor')
+  expect(result.name).toBe('test-name')
+  expect(result.author).toBe('test-author')
   expect(result.description).toBe('testing')
   expect(result.using).toBe('test')
   expect(result.isWorkflow).toBe(false)
@@ -42,9 +43,9 @@ test(`check parseYAML with quoted strings`, () => {
   const filePath = 'test'
   const result = parseYAML(filePath, 'test', content)
 
-  expect(result.name).toBe('test name')
-  expect(result.author).toBe('test author')
-  expect(result.description).toBe('testing with quotes')
+  expect(result.name).toBe('test "name"')
+  expect(result.author).toBe('test "author"')
+  expect(result.description).toBe('testing "with quotes"')
   expect(result.using).toBe('testwithquote')
   expect(result.isWorkflow).toBe(false)
 })
@@ -90,6 +91,38 @@ test(`Check sanitization`, () => {
   const value = 'Abc$%#6- ZZpp'
   const cleaned = sanitize(value)
   expect(cleaned).toBe('Abc6 ZZpp')
+})
+
+test(`removeGreaterLessThan preserves hyphens`, () => {
+  expect(removeGreaterLessThan('test-name')).toBe('test-name')
+})
+
+test(`removeGreaterLessThan encodes angle brackets`, () => {
+  expect(removeGreaterLessThan('<script>')).toBe('&#60;script&#62;')
+})
+
+test(`check parseYAML with angle brackets in name`, () => {
+  const content = `
+  name: '<xss>'
+  author: 'some-author'
+  description: 'testing <b>bold</b>'
+  runs:\n    using: 'node20'`
+  const filePath = 'test'
+  const result = parseYAML(filePath, 'test', content)
+
+  expect(result.name).toBe('&#60;xss&#62;')
+  expect(result.description).toBe('testing &#60;b&#62;bold&#60;/b&#62;')
+})
+
+test(`check parseYAML falls back to defaultValue when name/author/description are undefined`, () => {
+  const content = `
+  runs:\n    using: 'node20'`
+  const filePath = 'test'
+  const result = parseYAML(filePath, 'test', content)
+
+  expect(result.name).toBe('Undefined')
+  expect(result.author).toBe('Undefined')
+  expect(result.description).toBe('Undefined')
 })
 
 test('isInTestFolder detects __tests__ directories', () => {

--- a/dist/main.js
+++ b/dist/main.js
@@ -36819,6 +36819,7 @@ var init_multipart_parser = __esm({
 var main_exports = {};
 __export(main_exports, {
   ActionContent: () => ActionContent,
+  ContentBase: () => ContentBase,
   WorkflowContent: () => WorkflowContent
 });
 module.exports = __toCommonJS(main_exports);
@@ -44061,9 +44062,9 @@ function parseYAML(filePath, repo, content) {
       isWorkflow = true;
       return { name, author, description, using, isWorkflow };
     }
-    name = parsed.name ? sanitize(parsed.name) : defaultValue;
-    author = parsed.author ? sanitize(parsed.author) : defaultValue;
-    description = parsed.description ? sanitize(parsed.description) : defaultValue;
+    name = parsed.name ? removeGreaterLessThan(parsed.name) : defaultValue;
+    author = parsed.author ? removeGreaterLessThan(parsed.author) : defaultValue;
+    description = parsed.description ? removeGreaterLessThan(parsed.description) : defaultValue;
     if (parsed.runs) {
       using = parsed.runs.using ? sanitize(parsed.runs.using) : defaultValue;
     }
@@ -44080,6 +44081,7 @@ function parseYAML(filePath, repo, content) {
 function sanitize(value) {
   return import_string_sanitizer.default.sanitize.keepSpace(value);
 }
+var removeGreaterLessThan = (item) => item.replace(/>/g, "&#62;").replace(/</g, "&#60;");
 var getActionableDockerFilesFromDisk = async (path2) => {
   const dockerFilesWithActionArray = [];
   const dockerFiles = (0, import_child_process.execSync)(
@@ -45635,9 +45637,11 @@ async function run() {
     setFailed(`Error running action: : ${error2.message}`);
   }
 }
-var ActionContent = class {
+var ContentBase = class {
 };
-var WorkflowContent = class {
+var ActionContent = class extends ContentBase {
+};
+var WorkflowContent = class extends ContentBase {
 };
 async function getAllActions(client, user, organization, isEnterpriseServer, excludedRepos) {
   const forkedRepos = await getSearchResult(
@@ -46290,6 +46294,7 @@ run();
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
   ActionContent,
+  ContentBase,
   WorkflowContent
 });
 /*! Bundled license information:

--- a/src/main.ts
+++ b/src/main.ts
@@ -248,30 +248,27 @@ async function run(): Promise<void> {
   }
 }
 
-export class ActionContent {
+export class ContentBase {
   name: string | undefined
-  owner: string | undefined
   repo: string | undefined
-  path: string | undefined
   downloadUrl: string | undefined
-  author: string | undefined
   description: string | undefined
   forkedfrom: string | undefined
+  isArchived: boolean | undefined
+}
+
+export class ActionContent extends ContentBase {
+  owner: string | undefined
+  path: string | undefined
+  author: string | undefined
   readme: string | undefined
   using: string | undefined
-  isArchived: boolean | undefined
   visibility: string | undefined
   isFork: boolean | undefined
 }
 
-export class WorkflowContent {
-  name: string | undefined
+export class WorkflowContent extends ContentBase {
   owner: string | undefined
-  repo: string | undefined
-  downloadUrl: string | undefined
-  description: string | undefined
-  forkedfrom: string | undefined
-  isArchived: boolean | undefined
   visibility: string | undefined
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,10 +65,10 @@ export function parseYAML(
       return {name, author, description, using, isWorkflow}
     }
 
-    name = parsed.name ? sanitize(parsed.name) : defaultValue
-    author = parsed.author ? sanitize(parsed.author) : defaultValue
+    name = parsed.name ? removeGreaterLessThan(parsed.name) : defaultValue
+    author = parsed.author ? removeGreaterLessThan(parsed.author) : defaultValue
     description = parsed.description
-      ? sanitize(parsed.description)
+      ? removeGreaterLessThan(parsed.description)
       : defaultValue
 
     if (parsed.runs) {
@@ -92,6 +92,9 @@ export function parseYAML(
 export function sanitize(value: string) {
   return string.sanitize.keepSpace(value)
 }
+
+export const removeGreaterLessThan = (item: string): string =>
+  item.replace(/>/g, '&#62;').replace(/</g, '&#60;')
 
 // Interface for a Dockerfile with actionable properties
 export interface DockerActionFiles {


### PR DESCRIPTION
This PR reimplements the fix originally proposed by @GetTuh in #415, with the null-safety issue identified in review corrected.

## What changed

- Replaced sanitize() for name/author/description fields in parseYAML with a new removeGreaterLessThan() helper that only HTML-encodes < and > to prevent XSS while preserving valid characters like hyphens.
- Added ContentBase class with shared fields — ActionContent and WorkflowContent now extend it, reducing duplication.
- Updated tests: hyphens are now preserved, angle brackets are encoded, undefined fields fall back to 'Undefined'.

## Fix from the original PR

The original #415 called removeGreaterLessThan(parsed.name) directly without checking for undefined, which would throw at runtime. This PR uses safe null-check patterns for all three fields.

Closes #415 in favour of this cleaner implementation. Thanks @GetTuh for the original contribution!